### PR TITLE
Update telosevm-js to reduce logging and fix getCode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ethereumjs/common": "^2.4.0",
         "@ethereumjs/tx": "^3.3.0",
         "@greymass/eosio": "^0.6.4",
-        "@telosnetwork/telosevm-js": "0.2.8",
+        "@telosnetwork/telosevm-js": "0.3.1",
         "@types/uws": "^0.13.3",
         "abi-decoder": "^2.4.0",
         "bn.js": "^5.2.0",
@@ -793,9 +793,9 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/@telosnetwork/telosevm-js": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@telosnetwork/telosevm-js/-/telosevm-js-0.2.8.tgz",
-      "integrity": "sha512-mtW2QxFZyvrNb5QFdY2eLRV/+dfgrsukOyFp/dSRVmid/wFo+3UYe4BE6RgfJULj7ORwo+X/xLUE+EcK3mT2+Q==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@telosnetwork/telosevm-js/-/telosevm-js-0.3.1.tgz",
+      "integrity": "sha512-1kwYkQ4ONT7HqjCoUJS0Md/m8PE9CHC3JlRHygaYTy0hoHw9rfhoOKvn0/x7iAt3VehdKpMR6C2dg6CmF8AwVQ==",
       "dependencies": {
         "@ethereumjs/common": "^2.3.1",
         "@ethereumjs/tx": "^3.2.1",
@@ -2827,9 +2827,9 @@
       }
     },
     "@telosnetwork/telosevm-js": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@telosnetwork/telosevm-js/-/telosevm-js-0.2.8.tgz",
-      "integrity": "sha512-mtW2QxFZyvrNb5QFdY2eLRV/+dfgrsukOyFp/dSRVmid/wFo+3UYe4BE6RgfJULj7ORwo+X/xLUE+EcK3mT2+Q==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@telosnetwork/telosevm-js/-/telosevm-js-0.3.1.tgz",
+      "integrity": "sha512-1kwYkQ4ONT7HqjCoUJS0Md/m8PE9CHC3JlRHygaYTy0hoHw9rfhoOKvn0/x7iAt3VehdKpMR6C2dg6CmF8AwVQ==",
       "requires": {
         "@ethereumjs/common": "^2.3.1",
         "@ethereumjs/tx": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@ethereumjs/common": "^2.4.0",
     "@ethereumjs/tx": "^3.3.0",
     "@greymass/eosio": "^0.6.4",
-    "@telosnetwork/telosevm-js": "0.2.8",
+    "@telosnetwork/telosevm-js": "0.3.1",
     "@types/uws": "^0.13.3",
     "abi-decoder": "^2.4.0",
     "bn.js": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -408,10 +408,10 @@
     hash.js "^1.0.0"
     tslib "^2.0.3"
 
-"@telosnetwork/telosevm-js@0.2.8":
-  version "0.2.8"
-  resolved "https://registry.npmjs.org/@telosnetwork/telosevm-js/-/telosevm-js-0.2.8.tgz"
-  integrity sha512-mtW2QxFZyvrNb5QFdY2eLRV/+dfgrsukOyFp/dSRVmid/wFo+3UYe4BE6RgfJULj7ORwo+X/xLUE+EcK3mT2+Q==
+"@telosnetwork/telosevm-js@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.npmjs.org/@telosnetwork/telosevm-js/-/telosevm-js-0.3.1.tgz"
+  integrity sha512-1kwYkQ4ONT7HqjCoUJS0Md/m8PE9CHC3JlRHygaYTy0hoHw9rfhoOKvn0/x7iAt3VehdKpMR6C2dg6CmF8AwVQ==
   dependencies:
     "@ethereumjs/common" "^2.3.1"
     "@ethereumjs/tx" "^3.2.1"


### PR DESCRIPTION
This updates telosevm-js to 0.3.1 which changes the response from `getEthAccount` to include a 0x prefix on account.code.  It also no longer will throw an exception or logs when the account is not found.  Changes should reflect no more exception handling and replace that with a check for the response from `getEthAccount` to be undefined.