### PR TITLE
Dependency tweaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ethers": "^5.7.0",
     "keccak": "^3.0.2",
     "reconnecting-websocket": "^4.4.0",
-    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.15.0",
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.14.0",
     "ws": "^8.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,9 +956,9 @@ exit-on-epipe@~1.0.1:
   integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
 
 follow-redirects@^1.14.0:
-  version "1.14.6"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz"
-  integrity sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 foreach@^2.0.5:
   version "2.0.5"
@@ -1426,9 +1426,9 @@ typescript@4.4.3:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz"
   integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
-"uWebSockets.js@github:uNetworking/uWebSockets.js#v20.15.0":
-  version "20.15.0"
-  resolved "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#77bc1fd5577ae42b56675912eb8481a31f3fefd2"
+"uWebSockets.js@github:uNetworking/uWebSockets.js#v20.14.0":
+  version "20.14.0"
+  resolved "https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/873b0a4e9f55e66e1b6cac4767c476fbb3913eba"
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Bump follow-redirects from 1.14.6 to 1.15.2
Downgrade uWebsockets from 20.15.0 to 20.14.0 as we are unable to install 20.15.0